### PR TITLE
Chore: Add Deployment Pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ "main", "chore/add-deployment-pipeline" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ "main", "chore/add-deployment-pipeline" ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        
+    - name: Install dependencies
+      run: npm ci
+      
+    - name: Build
+      run: npm run build
+      
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+      
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: './dist'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -3,8 +3,15 @@
 <div align="center">
   <img src="https://shared.fastly.steamstatic.com/store_item_assets/steam/apps/2503770/b33b96f5e8795a6ddad37c3cc1e5abb3557b8274/capsule_616x353.jpg?t=1752485158" alt="House of Legacy Game Banner" width="600">
 </div>
+<br />
 
 A modern web-based save editor for [House of Legacy](https://store.steampowered.com/app/2503770/House_of_Legacy/), the addictive dynasty management game. This tool allows you to customize your save files to enhance your gameplay experience and skip the early-game grind.
+
+## 🌐 Quick Start
+
+**[✨ Try the Editor Online →](https://riandyrn.github.io/house-of-legacy-editor/)**
+
+*No installation required - runs entirely in your browser with secure client-side processing*
 
 ## ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A modern web-based save editor for [House of Legacy](https://store.steampowered.
    npm run dev
    ```
 
-4. Open your browser and navigate to `http://localhost:5173`
+4. Open your browser and navigate to `http://localhost:5173/house-of-legacy-editor/`
 
 ### Building for Production
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,4 +8,5 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
+  base: '/house-of-legacy-editor/',
 })


### PR DESCRIPTION
This pull request introduces automated deployment to GitHub Pages and updates the project configuration and documentation to support hosting the app at a custom sub-path. The changes ensure that users can easily access the editor online and that the app works seamlessly when deployed to GitHub Pages.

**Deployment automation:**

* Added a new GitHub Actions workflow in `.github/workflows/deploy.yml` to build and deploy the app to GitHub Pages on every push to the `main` branch.

**Configuration for GitHub Pages hosting:**

* Updated the `vite.config.js` file to set the `base` path to `/house-of-legacy-editor/`, ensuring correct asset resolution when hosted on GitHub Pages.

**Documentation updates:**

* Added a "Quick Start" section to the `README.md` with a link to the online editor and clarified that no installation is required.
* Updated local development instructions in the `README.md` to use the correct URL path (`/house-of-legacy-editor/`).