### PR TITLE
Feat: Split Finance & Resources

### DIFF
--- a/src/components/layout/EditorContent.jsx
+++ b/src/components/layout/EditorContent.jsx
@@ -56,32 +56,35 @@ function EditorContent() {
 		updateGameData(updatedGameData);
 	};
 
+	const handleMaxAllFinance = () => {
+		const resourceUtils = new ResourceUtils(gameData);
+		const updatedGameData = resourceUtils.maxAllFinance();
+		updateGameData(updatedGameData);
+	};
+
 	const handleMaxAllResources = () => {
 		const resourceUtils = new ResourceUtils(gameData);
 		const updatedGameData = resourceUtils.maxAllResources();
 		updateGameData(updatedGameData);
 	};
 
-
-
-
 	return (
 		<main className="bg-white rounded-lg shadow-lg p-6 mt-4">
 			<div className="border-b border-gray-200 mb-4">
 				<div className="flex justify-between items-end">
 					<nav aria-label="Tabs" className="-mb-px flex space-x-8">
-						{['clanMembers', 'spouses', 'retainers', 'resources'].map((tab) => (
+						{['clanMembers', 'spouses', 'retainers', 'financeResources'].map((tab) => (
 							<button
 								key={tab}
 								onClick={() => setActiveTab(tab)}
 								className={`whitespace-nowrap py-4 px-1 border-b-2 font-medium text-base ${activeTab === tab
-										? 'border-gray-800 text-gray-900'
-										: 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+									? 'border-gray-800 text-gray-900'
+									: 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
 									}`}
 							>
 								{tab === 'clanMembers' ? 'Clan Members' :
 									tab === 'spouses' ? 'Spouses' :
-										tab === 'retainers' ? 'Retainers' : 'Resources'}
+										tab === 'retainers' ? 'Retainers' : 'Finance & Resources'}
 							</button>
 						))}
 					</nav>
@@ -147,11 +150,19 @@ function EditorContent() {
 					)}
 
 					{/* Resources Tab Buttons */}
-					{activeTab === 'resources' && (
-						<div className="flex items-center space-x-4 py-4">
-							<button onClick={handleMaxAllResources} className="bg-gray-800 text-white px-4 py-1.5 rounded-md text-sm font-medium hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-600">
-								Max All Resources
-							</button>
+					{activeTab === 'financeResources' && (
+						<div className="flex items-center space-x-2 py-4">
+							<div className="flex items-center">
+								<button onClick={handleMaxAllFinance} className="bg-gray-800 text-white px-4 py-1.5 rounded-md text-sm font-medium hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-600">
+									Max All Finance
+								</button>
+							</div>
+							<div className="text-gray-300 text-sm">|</div>
+							<div className="flex items-center">
+								<button onClick={handleMaxAllResources} className="bg-gray-800 text-white px-4 py-1.5 rounded-md text-sm font-medium hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-600">
+									Max All Resources
+								</button>
+							</div>
 						</div>
 					)}
 				</div>
@@ -172,8 +183,8 @@ function EditorContent() {
 				<RetainerTable />
 			)}
 
-			{/* Resources Table */}
-			{activeTab === 'resources' && (
+			{/* Finance & Resources Table */}
+			{activeTab === 'financeResources' && (
 				<ResourceTable />
 			)}
 

--- a/src/utils/resourceUtils.js
+++ b/src/utils/resourceUtils.js
@@ -3,11 +3,11 @@ import { maxResourceValues } from '../constants/gameConstants';
 class ResourceUtils {
   constructor(gameData) {
     this.gameData = structuredClone(gameData);
-    
+
     // Find index storage for food, vegetables, meat
     const props = this.gameData.Prop_have.value;
     let idxFood, idxVegetables, idxMeat;
-    
+
     for (let i = 0; i < props.length; i++) {
       const [id, _] = props[i];
       switch (id) {
@@ -117,26 +117,30 @@ class ResourceUtils {
     // Update money and yuanbao
     this.gameData.CGNum.value[0] = updatedResource.money.toString();
     this.gameData.CGNum.value[1] = updatedResource.yuanbao.toString();
-    
+
     // Update food, vegetables, and meat
     this.gameData.Prop_have.value[this.idxFood][1] = updatedResource.food.toString();
     this.gameData.Prop_have.value[this.idxVegetables][1] = updatedResource.vegetables.toString();
     this.gameData.Prop_have.value[this.idxMeat][1] = updatedResource.meat.toString();
-    
+
+    return this.gameData;
+  }
+
+  maxAllFinance() {
+    // Set money and yuanbao to maximum
+    this.gameData.CGNum.value[0] = maxResourceValues.money.toString();
+    this.gameData.CGNum.value[1] = maxResourceValues.yuanbao.toString();
+
     return this.gameData;
   }
 
   // Max all resources
   maxAllResources() {
-    // Set money and yuanbao to maximum
-    this.gameData.CGNum.value[0] = maxResourceValues.money.toString();
-    this.gameData.CGNum.value[1] = maxResourceValues.yuanbao.toString();
-    
     // Set food, vegetables, and meat to maximum
     this.gameData.Prop_have.value[this.idxFood][1] = maxResourceValues.food.toString();
     this.gameData.Prop_have.value[this.idxVegetables][1] = maxResourceValues.vegetables.toString();
     this.gameData.Prop_have.value[this.idxMeat][1] = maxResourceValues.meat.toString();
-    
+
     return this.gameData;
   }
 }


### PR DESCRIPTION
This pull request updates the resource management section in the editor, making it easier for users to maximize both financial and resource values. The key changes include splitting the previous "Resources" tab into a new "Finance & Resources" tab, adding a dedicated button to maximize financial resources, and refactoring the underlying utility functions to support this new functionality.

**UI/UX Improvements:**

* Renamed the `resources` tab to `financeResources` and updated the tab label from "Resources" to "Finance & Resources" for better clarity in the navigation bar. [[1]](diffhunk://#diff-6a9c9245517f6eb580108916bc544f86be20691274dea53d3632000a5b8276dfR59-R76) [[2]](diffhunk://#diff-6a9c9245517f6eb580108916bc544f86be20691274dea53d3632000a5b8276dfL84-R87)
* Updated the tab content to show both "Max All Finance" and "Max All Resources" buttons, allowing users to separately maximize financial values (money, yuanbao) and other resources.

**Functionality Enhancements:**

* Added a new handler function `handleMaxAllFinance` in `EditorContent.jsx` to trigger maximizing all finance-related values using the `ResourceUtils.maxAllFinance` method.
* Refactored `ResourceUtils` by introducing a new `maxAllFinance` method that sets money and yuanbao to their maximum values, separating this logic from the existing `maxAllResources` method.

**Component Rendering Updates:**

* Updated the conditional rendering logic so that the `ResourceTable` is now displayed under the `financeResources` tab instead of the old `resources` tab.